### PR TITLE
jwchat fixes

### DIFF
--- a/setup.d/90_jwchat
+++ b/setup.d/90_jwchat
@@ -4,8 +4,9 @@
 
 set -e
 
-# Set hostname for ejabberd
+# Set hostname for ejabberd and jwchat
 echo "ejabberd ejabberd/hostname string `hostname`" | debconf-set-selections
+echo "jwchat jwchat/ApacheServerName string `hostname`" | debconf-set-selections
 
 # An alternative XMPP server is prosody
 apt-get install -y jwchat ejabberd


### PR DESCRIPTION
This fixes the ejabberd and jwchat configuration to let jwchat connect without error. (I haven't tested much beyond the initial connection.)

Related TODOs:
1. Create XMPP user accounts through Plinth (currently need to use ejabberdctl).
2. Update hostnames for ejabberd and jwchat if changed through Plinth.
