### PR TITLE
Fix network interface re-naming on Dreamplug.

### DIFF
--- a/first-run.d/05_network
+++ b/first-run.d/05_network
@@ -40,7 +40,7 @@ EOF
 
     # always name interfaces in same order as MAC addresses
     service networking restart
-    MACS=$(ifconfig | grep eth | cut -c39-55 | sort)
+    MACS=$(ifconfig | awk '/Ethernet/ { print $5 }' | sort)
     COUNT=0
     for MAC in $MACS; do
         export MATCHADDR=$MAC


### PR DESCRIPTION
After configuring /etc/network/interfaces, restart the networking service and grab the MAC addresses from ifconfig. Sort them and write out persistent-net rules for udev. (1st MAC address is eth0, 2nd is eth1.)

Tested by rebooting the dreamplug several times, and checking that the interfaces weren't swapped.
