### PR TITLE
Fix lxc template install location.

### DIFF
--- a/debian/freedombox-setup.install
+++ b/debian/freedombox-setup.install
@@ -6,4 +6,4 @@ sysctl.d/freedombox-setup.conf etc/sysctl.d
 sbin/copy2dream usr/sbin
 sbin/dreamplug-detect usr/sbin
 doc/README home/fbx
-lxc-templates/lxc-debian-freedombox /usr/share/lxc/templates
+lxc-templates/lxc-debian-freedombox usr/share/lxc/templates


### PR DESCRIPTION
Use relative path so it will install correctly through vmdebootstrap.
