### PR TITLE
Force overwrite of snakeoil certificates during first run script.

### DIFF
--- a/first-run.d/40_apache2
+++ b/first-run.d/40_apache2
@@ -3,4 +3,4 @@
 # Make sure every machine have their own unique SSL certificate, even
 # if it is a snake oil one.
 
-make-ssl-cert generate-default-snakeoil
+make-ssl-cert generate-default-snakeoil --force-overwrite


### PR DESCRIPTION
This will ensure that the snakeoil cert is actually re-generated in first-run.

However, the plinth-server test still fails due to "TLS warning alert" from GnuTLS.
