### PR TITLE
Don't disable Tor socks port.

### DIFF
--- a/setup.d/80_tor
+++ b/setup.d/80_tor
@@ -3,7 +3,6 @@
 apt-get install -y tor
 
 cat > /etc/tor/torrc <<EOF
-SocksPort 0
 ORPort 4431
 BridgeRelay 1
 Exitpolicy reject *:*


### PR DESCRIPTION
This opens the default Socks port (9050).
