### PR TITLE
Get correct hostname for ejabberd and jwchat, when run inside a chroot.

### DIFF
--- a/setup.d/85_jwchat
+++ b/setup.d/85_jwchat
@@ -5,8 +5,8 @@
 set -e
 
 # Set hostname for ejabberd and jwchat
-echo "ejabberd ejabberd/hostname string `hostname`" | debconf-set-selections
-echo "jwchat jwchat/ApacheServerName string `hostname`" | debconf-set-selections
+echo "ejabberd ejabberd/hostname string `cat /etc/hostname`" | debconf-set-selections
+echo "jwchat jwchat/ApacheServerName string `cat /etc/hostname`" | debconf-set-selections
 
 # An alternative XMPP server is prosody
 apt-get install -y jwchat ejabberd


### PR DESCRIPTION
Tested that this script works both within and outside of a chroot.
