### PR TITLE
Fix wifi ap setup

### DIFF
--- a/first-run.d/30_wifi-ap-setup
+++ b/first-run.d/30_wifi-ap-setup
@@ -5,7 +5,8 @@
 echo "Configuring WIFI..."
 
 # If users have selected non-free packages, install firmware-libertas.
-if [ -z /sbin/machine-detect ]
+. machine-detect
+if [ "$MACHINE" = "dreamplug" ]
 then
     if [ -n `grep nonfree /etc/apt/sources.list` ]
     then


### PR DESCRIPTION
For wifi AP setup, source machine-detect and check if $MACHINE is dreamplug.
