### PR TITLE
Rewrite Tor obfsproxy test to avoid relying on log file.

### DIFF
--- a/testsuite/tor-client.test
+++ b/testsuite/tor-client.test
@@ -30,7 +30,6 @@ do
 done
 
 # Check obfsproxy transports
-register_logs=`grep "Registered server transport" /var/log/tor/log`
 transports="obfs3 scramblesuit"
 for transport in $transports
 do


### PR DESCRIPTION
The obfsproxy lines can get erased from the log after a while, and we might want to disable logging in the future.
