### PR TITLE
Add apache conf for jwchat, separate from fbx site conf.

### DIFF
--- a/setup.d/85_jwchat
+++ b/setup.d/85_jwchat
@@ -17,8 +17,24 @@ if ! grep -q mod_http_bind /etc/ejabberd/ejabberd.cfg ; then
   {mod_http_bind, []},' /etc/ejabberd/ejabberd.cfg
 fi
 
-# We'll use another site to serve jwchat.
+# setup jwchat apache conf
+cat > /etc/apache2/conf-available/jwchat.conf <<'EOF'
+Alias /jwchat /usr/share/jwchat/www
+
+<Directory /usr/share/jwchat/www>
+    Options +Indexes +Multiviews +FollowSymLinks
+</Directory>
+
+# proxy for BOSH server
+ProxyPass /http-bind/ http://localhost:5280/http-bind/
+ProxyPassReverse /http-bind/ http://localhost:5280/http-bind/
+<Proxy *>
+    Allow from all
+</Proxy>
+EOF
+
 a2dissite jwchat
+a2enconf jwchat
 
 # Remove SSL keys from images, will be generated on first boot.
 rm -f /etc/ejabberd/ejabberd.pem


### PR DESCRIPTION
This adds a jwchat.conf file under /etc/apache2/conf-available and enables it. It's a similar setup to owncloud. Now jwchat is available at http://freedombox.local/jwchat and https://freedombox.local/jwchat.

I didn't remove the old jwchat conf from the fbx.conf site yet, because plinth links to that URL. If this change looks good then I'll update the link in plinth, so the old stuff can be removed.
