### PR TITLE
Skip backup in rpi-update.

### DIFF
--- a/setup.d/10_hardware
+++ b/setup.d/10_hardware
@@ -70,7 +70,7 @@ raspberry_setup_boot() {
     chmod a+x /usr/bin/rpi-update
     mkdir -p /lib/modules
     touch /boot/start.elf
-    rpi-update > /root/rpi-update.log
+    SKIP_BACKUP=1 rpi-update > /root/rpi-update.log
 
 }
 


### PR DESCRIPTION
The do_backup function was changed recently in rpi-update:
https://github.com/Hexxeh/rpi-update/commit/41e23a0924d18786ac2374b04277d1223bdec614

Since the kernel isn't installed before rpi-update run, and they don't check that the module folder exists before trying to copy it, this causes an error. Adding the SKIP_BACKUP=1 option avoids the error.
