### PR TITLE
Beaglebone: Use debian packaged kernel

### DIFF
--- a/setup.d/10_hardware
+++ b/setup.d/10_hardware
@@ -2,7 +2,7 @@
 
 enable_serial_console() {
     # By default, spawn a console on the serial port
-    device = "$1"
+    device="$1"
     echo "Adding a getty on the serial port"
     echo "T0:12345:respawn:/sbin/getty -L $device 115200 vt100" >> /etc/inittab
 }


### PR DESCRIPTION
Use debian packaged linux-image-armmp, which supports beaglebone as of 3.14-1 (in sid currently).

Since the serial debug console has a different device name, I added a parameter to the enable_serial_console function so we can specify for each hardware type.
