### PR TITLE
Remove IPv6 configuration from networking auto-config.

### DIFF
--- a/first-run.d/05_network
+++ b/first-run.d/05_network
@@ -96,7 +96,7 @@ auto eth1
     netmask 255.255.255.0
     #iface eth1 inet6 static
     #address 2002:c0a8:0101::1
-    netmask 64
+    #netmask 64
     # eth1: hwaddress ether 00:00:00:00:00:02
 
 EOF


### PR DESCRIPTION
Networking seems to choke on the inet6 lines in
`/etc/network/interfaces`, so I've removed them.  When the networking
system chokes, it appears to stop processing further lines for the
entry it was on.  This means that it never got to the `hwaddress
ether` lines, which prevented networking from ever setting a MAC
address for the interface, if one wasn't already provided.

Of course, those hwaddress lines were uncommented only on DreamPlugs
that had already lost their original MAC addresses, giving them
invalid, null, MAC addresses.

Next steps: figure out why networking is choking on the IPv6 lines.
