### PR TITLE
Enable Tor transparent proxy.

### DIFF
--- a/first-run.d/81_tor
+++ b/first-run.d/81_tor
@@ -1,10 +1,16 @@
 #!/bin/sh
 
-# Add a SocksPort on each configured network interface.
+# Enable SOCKS and transparent proxy on each configured network interface.
 ips=$(ip -4 -o addr | awk '!/^[0-9]*: ?lo|link\/ether/ {gsub("/", " "); print $4}')
 for ip in $ips
 do
     if ! grep -q "SocksPort $ip:9050" /etc/tor/torrc ; then
         echo "SocksPort $ip:9050" >> /etc/tor/torrc
+    fi
+    if ! grep -q "TransPort $ip:9040" /etc/tor/torrc ; then
+        echo "TransPort $ip:9040" >> /etc/tor/torrc
+    fi
+    if ! grep -q "DNSPort $ip:53" /etc/tor/torrc ; then
+        echo "DNSPort $ip:53" >> /etc/tor/torrc
     fi
 done

--- a/setup.d/80_tor
+++ b/setup.d/80_tor
@@ -6,10 +6,20 @@
 apt-get install -y tor obfsproxy
 
 cat > /etc/tor/torrc <<EOF
+# run as non-exit bridge relay
 SocksPort 127.0.0.1:9050
 ORPort auto
 ControlPort 9051
 BridgeRelay 1
 Exitpolicy reject *:*
+
+# enable obfsproxy
 ServerTransportPlugin obfs3 exec /usr/bin/obfsproxy managed
+
+# enable transparent proxy
+VirtualAddrNetworkIPv4 10.192.0.0/10
+AutomapHostsOnResolve 1
+TransPort 127.0.0.1:9040
+DNSPort 127.0.0.1:53
+
 EOF

--- a/testsuite/tor-client.test
+++ b/testsuite/tor-client.test
@@ -6,6 +6,10 @@ netstat_check `tor-get-orport` tcp tor
 netstat_check `tor-get-orport` tcp6 tor
 netstat_check 9050 tcp tor
 netstat_check 9050 tcp6 tor
+netstat_check 9040 tcp tor
+netstat_check 9040 tcp6 tor
+netstat_check_socket 127.0.0.1:domain udp tor
+netstat_check_socket 127.0.0.1:domain udp6 tor
 
 # Tor control socket
 ip="127.0.0.1"


### PR DESCRIPTION
Added initial Tor configuration to enable transparent proxy. Based on this example:
https://trac.torproject.org/projects/tor/wiki/doc/TransparentProxy#LocalRedirectionandAnonymizingMiddlebox

There are still a few other things that will need to be done to actually use it though:
1. Firewall configuration to redirect outgoing traffic.
2. Probably need to disable other DNS servers when the redirection is switched on.
