### PR TITLE
Remove changes to old config file. New ejabberd package uses yml config.

### DIFF
--- a/setup.d/85_jwchat
+++ b/setup.d/85_jwchat
@@ -11,22 +11,6 @@ echo "jwchat jwchat/ApacheServerName string `cat /etc/hostname`" | debconf-set-s
 # An alternative XMPP server is prosody
 apt-get install -y jwchat ejabberd
 
-# Enable IPv6 for c2s, s3s, and http connections.
-if ! grep -q inet6 /etc/ejabberd/ejabberd.cfg ; then
-    sed -i '/{5222, ejabberd_c2s, \[/a \
-			inet6,' /etc/ejabberd/ejabberd.cfg
-    sed -i '/{5269, ejabberd_s2s_in, \[/a \
-                           inet6,' /etc/ejabberd/ejabberd.cfg
-    sed -i '/{5280, ejabberd_http, \[/a \
-                         inet6,' /etc/ejabberd/ejabberd.cfg
-fi
-
-# Enable BOSH module for ejabberd
-if ! grep -q mod_http_bind /etc/ejabberd/ejabberd.cfg ; then
-    sed -i '/mod_last/i \
-  {mod_http_bind, []},' /etc/ejabberd/ejabberd.cfg
-fi
-
 # setup jwchat apache conf
 cat > /etc/apache2/conf-available/jwchat.conf <<'EOF'
 Alias /jwchat /usr/share/jwchat/www


### PR DESCRIPTION
Remove lines that would cause the script to fail with ejabberd >= 14.07-1.

With the new package, mod_http_bind is enabled by default.

I think https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=503313 is not really fixed yet, so there's no IPv6 by default. But I'll try to get that issue fixed in the ejabberd package instead of using a work-around here.
