### PR TITLE
Minor updates to Tor config

### DIFF
--- a/setup.d/80_tor
+++ b/setup.d/80_tor
@@ -14,7 +14,8 @@ BridgeRelay 1
 Exitpolicy reject *:*
 
 # enable obfsproxy
-ServerTransportPlugin obfs3 exec /usr/bin/obfsproxy managed
+ServerTransportPlugin obfs3,scramblesuit exec /usr/bin/obfsproxy managed
+ExtORPort auto
 
 # enable transparent proxy
 VirtualAddrNetworkIPv4 10.192.0.0/10


### PR DESCRIPTION
1. Enable scramblesuit plugin for obfsproxy. This should now work correctly with the new version of tor (0.2.5 currently in unstable).
2. Enable ExtORPort for local communication between tor and obfsproxy. This socket is bound to localhost and used for gathering statistics. (This thread has some details: https://lists.torproject.org/pipermail/tor-relays/2014-February/003908.html)
