### PR TITLE
Activate unattended upgrades from any Debian origin.

### DIFF
--- a/setup.d/97_unattended-upgrades
+++ b/setup.d/97_unattended-upgrades
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+# Activate unattended-upgrades.
+cat > /etc/apt/apt.conf.d/20auto-upgrades <<EOF
+APT::Periodic::Update-Package-Lists "1";
+APT::Periodic::Unattended-Upgrade "1";
+EOF
+
+if ! grep -q '"origin=Debian";' /etc/apt/apt.conf.d/50unattended-upgrades ; then
+    sed -i '/Unattended-Upgrade::Origins-Pattern {/a \
+        "origin=Debian";' /etc/apt/apt.conf.d/50unattended-upgrades
+fi


### PR DESCRIPTION
Although unattended-upgrades is installed, it doesn't seem to do anything by default. I added some configuration to activate it for periodic upgrades (following https://wiki.debian.org/UnattendedUpgrades#A20auto-upgrades).

Also by default, it only does security upgrades. I added an origin pattern so that it will upgrade any package from Debian.