### PR TITLE
Beaglebone updates

### DIFF
--- a/setup.d/10_hardware
+++ b/setup.d/10_hardware
@@ -76,10 +76,6 @@ raspberry_setup_boot() {
 }
 
 beaglebone_setup_boot() {
-    # copy u-boot to the boot partition
-    cp /usr/lib/u-boot/am335x_boneblack/MLO /boot/MLO
-    cp /usr/lib/u-boot/am335x_boneblack/u-boot.img /boot/u-boot.img
-
     # Setup uEnv.txt
     if grep -q btrfs /etc/fstab ; then
 	fstype=btrfs

--- a/setup.d/10_hardware
+++ b/setup.d/10_hardware
@@ -198,8 +198,7 @@ case "$MACHINE" in
 	;;
     beaglebone)
 	beaglebone_setup_boot
-	# flash-kernel will overwrite our uEnv.txt, so don't include it for now.
-	#beaglebone_flash
+	beaglebone_flash
 	beaglebone_repack_kernel
 	enable_serial_console ttyO0
 	;;


### PR DESCRIPTION
Some updates for beaglebone, to match a recent change to freedom-maker (https://github.com/freedombox/freedom-maker/commit/8bfa4951644a43d077a7eca3db5126496c8027c5).
1. Don't need to copy u-boot to /boot anymore. It's installed in offset space in front of 1st partition.
2. With change to ext2 for boot partition, flash-kernel is working without errors now. Re-enable it to help with kernel upgrades.
