### PR TITLE
Split network interfaces config into separate files

### DIFF
--- a/first-run.d/05_network
+++ b/first-run.d/05_network
@@ -6,12 +6,22 @@
 #
 # First parameter is the path to the network interface file to
 # configure.
+#
+# Second parameter is the path to the directory that will store
+# separate configuration files for each network interface.
 
 if [ -n "$1" ]
 then
     IFACES_FILE=$1
 else
     IFACES_FILE=/etc/network/interfaces
+fi
+
+if [ -n "$2" ]
+then
+    IFACES_DIR=$2
+else
+    IFACES_DIR=/etc/network/interfaces.d
 fi
 
 INTERFACE_DETECT="interface-detect"
@@ -52,6 +62,10 @@ function interfaces-start {
     cat > $IFACES_FILE <<EOF
 # This file describes the network interfaces available on your system
 # and how to activate them. For more information, see interfaces(5).
+
+# Include interfaces configured in separate files
+source $IFACES_DIR/*.conf
+
 EOF
 }
 
@@ -69,7 +83,7 @@ EOF
 function interfaces-eth0 {
     # add eth0 to interfaces file
 
-    cat >> $IFACES_FILE <<EOF
+    cat > $IFACES_DIR/eth0.conf <<EOF
 # The primary network interface
 # creates a new network.
 auto eth0
@@ -83,7 +97,7 @@ EOF
 function interfaces-eth1 {
     # add eth1 to interfaces file
 
-    cat >> $IFACES_FILE <<EOF
+    cat > $IFACES_DIR/eth1.conf <<EOF
 # The secondary network interface
 # joins the existing network.
 auto eth1

--- a/first-run.d/30_wifi-ap-setup
+++ b/first-run.d/30_wifi-ap-setup
@@ -17,8 +17,8 @@ then
 	modprobe -r mwifiex_sdio
 	modprobe mwifiex_sdio
 
-        echo "Adding uap0 to interfaces file."
-        cat >> /etc/network/interfaces <<EOF
+        echo "Setting up uap0 interface configuration..."
+        cat > /etc/network/interfaces.d/uap0.conf <<EOF
 # The wireless network interface
 # creates a new wireless network.
 auto uap0

--- a/first-run.d/30_wifi-ap-setup
+++ b/first-run.d/30_wifi-ap-setup
@@ -61,6 +61,7 @@ wpa_passphrase=freedombox123
 wpa_key_mgmt=WPA-PSK
 rsn_pairwise=CCMP
 EOF
+    chmod 660 /etc/hostapd/fbx-uap0.conf
 
     echo "Creating uap0 interface..."
     iw phy phy0 interface add uap0 type __ap


### PR DESCRIPTION
1. Use a separate file for each network interface. This should make it a bit easier for Plinth to add interfaces or modify their settings.
2. Set permissions for Dreamplug wifi AP config file so the WPA passphrase can't be read by everyone.